### PR TITLE
Possibly fixed bug "Channel height adjust appears to not work in channel lane area now"

### DIFF
--- a/fluxtream-web/src/main/webapp/js/applications/calendar/tabs/timeline/TimelineTab.js
+++ b/fluxtream-web/src/main/webapp/js/applications/calendar/tabs/timeline/TimelineTab.js
@@ -22,6 +22,7 @@ define(["applications/calendar/tabs/Tab", "core/FlxState", "applications/calenda
     var hasUnsavedChanges    = false; // used by unsaved changes dialog handler
     var loadedViewStr        = "";    // JSON string of loaded view
     var addPaneChannelsState = [];    // add channels pane channel visibility
+    var CHANNEL_PADDING      = 3;     // Pixels between plot and drag area
 
     /// A helper to create a data fetcher for the specified URL prefix
     ///
@@ -690,6 +691,8 @@ define(["applications/calendar/tabs/Tab", "core/FlxState", "applications/calenda
             "deviceName"       : channel["device_name"],
             "channelName"      : channel["channel_name"],
             "channelHeight"    : channel["channel_height"],
+            "channelTabHeight" : channel["channel_height"] + CHANNEL_PADDING,
+            "CHANNEL_PADDING"  : CHANNEL_PADDING,
             "plotId"           : id,
             "plotElementId"    : plotElementId,
             "channelElementId" : channelElementId,
@@ -2543,13 +2546,13 @@ define(["applications/calendar/tabs/Tab", "core/FlxState", "applications/calenda
             var yAxis = plot.getVerticalAxis();
             var yAixsW = $("#" + yAxis.getPlaceholder()).width();
 
-            var dragAreaH = $("._timeline_dragArea").height();
+            var dragAreaH = $("._timeline_dragArea").height() - CHANNEL_PADDING;
 
             if ((dy > 0) || (Math.abs(dy) < containerH)) {
-                // There is a min height of 70, which is taken from the
+                // There is a min height of 67, which is taken from the
                 // min height of the channel label
-                if (containerH + dy + dragAreaH < 70) {
-                    dy = 70 - containerH - dragAreaH;
+                if (containerH + dy + dragAreaH < 67) {
+                    dy = 67 - containerH - dragAreaH;
                 }
 
                 // Set the size of the plot container itself
@@ -2563,7 +2566,8 @@ define(["applications/calendar/tabs/Tab", "core/FlxState", "applications/calenda
                     SequenceNumber.getNext());
 
                 // Set the size of the channel label
-                $("#_timeline_channelTab_" + plotId).height(containerH + dy);
+                $("#_timeline_channelTab_" + plotId).height(
+                    containerH + dy + CHANNEL_PADDING);
 
                 // Update the view data to match the new channel height
                 if ((!!VIEWS.data) && (!!VIEWS.data["v2"])

--- a/fluxtream-web/src/main/webapp/js/applications/calendar/tabs/timeline/template.html
+++ b/fluxtream-web/src/main/webapp/js/applications/calendar/tabs/timeline/template.html
@@ -74,10 +74,10 @@
       <div class="_timeline_channelTabAndPlot">
         <table border="0" cellpadding="0" cellspacing="0">
           <tr>
-            <td class="_timeline_channeltd">
+            <td class="_timeline_channeltd" rowspan="2">
               <div class="_timeline_channelTab"
                 id="_timeline_channelTab_{{plotId}}"
-                style="height: {{channelHeight}}px">
+                style="height: {{channelTabHeight}}px">
                 <table border="0" cellpadding="0" cellspacing="0" class="_timeline_channelTable">
                   <tr>
                     <td valign="middle" style="width:32px"><div id="{{channelElementId}}_delete_btn" class="_timeline_delete_btn"></div></td>
@@ -122,6 +122,11 @@
                 <div id="{{yAxisElementId}}" class="_timeline_yAxis"
                   style="height: {{channelHeight}}px"></div>
               </div>
+            </td>
+          </tr>
+          <tr>
+            <td colspan="2">
+              <div style="height: {{CHANNEL_PADDING}}px"></div>
             </td>
           </tr>
           <tr>


### PR DESCRIPTION
However, haven't tested on sufficiently many browsers to know if the bug is fixed for sure.

To fix the bug, added a 3-pixel buffer underneath the channel lane on the timeline.  This compensates for the oversized div that GWT-G2D uses to wrap its canvas element.
