### PR TITLE
Fixing today button in Calendar

### DIFF
--- a/fluxtream-web/src/main/webapp/js/applications/calendar/App.js
+++ b/fluxtream-web/src/main/webapp/js/applications/calendar/App.js
@@ -161,6 +161,10 @@ define(["core/Application", "core/FlxState", "applications/calendar/Builder", "l
 					Calendar.currentTab.saveState();
 				}
 				Calendar.tabState = response.state;
+                if (Calendar.timeUnit != response.timeUnit) {
+                    Calendar.timeUnit = response.timeUnit;
+                    Calendar.renderState(Calendar.currentTabName + "/" + Calendar.tabState + (Calendar.tabParam == null ? "" : "/" + Calendar.tabParam));
+                }
                 updateDisplays();
                 Calendar.start = response.start;
                 Calendar.end  = response.end;


### PR DESCRIPTION
This wasn't calling Calendar.renderState() on pressing the today button,
causing the Clock tab to remain hidden. This diff fixes that by forcing
a re-render when the timeUnit is changed.
