### PR TITLE
Fixed unittests

### DIFF
--- a/fluxtream-core/src/test/java/org/fluxtream/core/domain/TagFilterTest.java
+++ b/fluxtream-core/src/test/java/org/fluxtream/core/domain/TagFilterTest.java
@@ -43,34 +43,41 @@ public final class TagFilterTest {
         testUntagged(TagFilter.create(tagsWithDuplicateItems, TagFilter.FilteringStrategy.UNTAGGED));
         testUntagged(TagFilter.create(tagsWithAllEmptyItems, TagFilter.FilteringStrategy.UNTAGGED));
 
-        testTagFilter(TagFilter.create(oneTag, TagFilter.FilteringStrategy.ALL), TagFilter.FilteringStrategy.ALL, 1, "facet.tags like '%,foo,%'");
-        testTagFilter(TagFilter.create(multipleTags, TagFilter.FilteringStrategy.ALL), TagFilter.FilteringStrategy.ALL, 2, "facet.tags like '%,foo,%' AND facet.tags like '%,bar,%'");
-        testTagFilter(TagFilter.create(tagsWithDuplicateItems, TagFilter.FilteringStrategy.ALL), TagFilter.FilteringStrategy.ALL, 2, "facet.tags like '%,foo,%' AND facet.tags like '%,bar,%'");
-        testTagFilter(TagFilter.create(tagsWithOneEmptyItem, TagFilter.FilteringStrategy.ALL), TagFilter.FilteringStrategy.ALL, 1, "facet.tags like '%,foo,%'");
+        testTagFilter(TagFilter.create(oneTag, TagFilter.FilteringStrategy.ALL), TagFilter.FilteringStrategy.ALL, 1, new String[]{"facet.tags like '%,foo,%'"});
+        testTagFilter(TagFilter.create(multipleTags, TagFilter.FilteringStrategy.ALL), TagFilter.FilteringStrategy.ALL, 2, new String[]{"facet.tags like '%,foo,%'", "AND", "facet.tags like '%,bar,%'"});
+        testTagFilter(TagFilter.create(tagsWithDuplicateItems, TagFilter.FilteringStrategy.ALL), TagFilter.FilteringStrategy.ALL, 2, new String[]{"facet.tags like '%,foo,%'", "AND", "facet.tags like '%,bar,%'"});
+        testTagFilter(TagFilter.create(tagsWithOneEmptyItem, TagFilter.FilteringStrategy.ALL), TagFilter.FilteringStrategy.ALL, 1, new String[]{"facet.tags like '%,foo,%'"});
 
-        testTagFilter(TagFilter.create(oneTag, TagFilter.FilteringStrategy.ANY), TagFilter.FilteringStrategy.ANY, 1, "facet.tags like '%,foo,%'");
-        testTagFilter(TagFilter.create(multipleTags, TagFilter.FilteringStrategy.ANY), TagFilter.FilteringStrategy.ANY, 2, "facet.tags like '%,foo,%' OR facet.tags like '%,bar,%'");
-        testTagFilter(TagFilter.create(tagsWithDuplicateItems, TagFilter.FilteringStrategy.ANY), TagFilter.FilteringStrategy.ANY, 2, "facet.tags like '%,foo,%' OR facet.tags like '%,bar,%'");
-        testTagFilter(TagFilter.create(tagsWithOneEmptyItem, TagFilter.FilteringStrategy.ANY), TagFilter.FilteringStrategy.ANY, 1, "facet.tags like '%,foo,%'");
+        testTagFilter(TagFilter.create(oneTag, TagFilter.FilteringStrategy.ANY), TagFilter.FilteringStrategy.ANY, 1, new String[]{"facet.tags like '%,foo,%'"});
+        testTagFilter(TagFilter.create(multipleTags, TagFilter.FilteringStrategy.ANY), TagFilter.FilteringStrategy.ANY, 2, new String[]{"facet.tags like '%,foo,%'", "OR", "facet.tags like '%,bar,%'"});
+        testTagFilter(TagFilter.create(tagsWithDuplicateItems, TagFilter.FilteringStrategy.ANY), TagFilter.FilteringStrategy.ANY, 2, new String[]{"facet.tags like '%,foo,%'", "OR", "facet.tags like '%,bar,%'"});
+        testTagFilter(TagFilter.create(tagsWithOneEmptyItem, TagFilter.FilteringStrategy.ANY), TagFilter.FilteringStrategy.ANY, 1, new String[]{"facet.tags like '%,foo,%'"});
 
-        testTagFilter(TagFilter.create(oneTag, TagFilter.FilteringStrategy.NONE), TagFilter.FilteringStrategy.NONE, 1, "facet.tags is NULL OR (facet.tags NOT like '%,foo,%')");
-        testTagFilter(TagFilter.create(multipleTags, TagFilter.FilteringStrategy.NONE), TagFilter.FilteringStrategy.NONE, 2, "facet.tags is NULL OR (facet.tags NOT like '%,foo,%' AND facet.tags NOT like '%,bar,%')");
-        testTagFilter(TagFilter.create(tagsWithDuplicateItems, TagFilter.FilteringStrategy.NONE), TagFilter.FilteringStrategy.NONE, 2, "facet.tags is NULL OR (facet.tags NOT like '%,foo,%' AND facet.tags NOT like '%,bar,%')");
-        testTagFilter(TagFilter.create(tagsWithOneEmptyItem, TagFilter.FilteringStrategy.NONE), TagFilter.FilteringStrategy.NONE, 1, "facet.tags is NULL OR (facet.tags NOT like '%,foo,%')");
+        testTagFilter(TagFilter.create(oneTag, TagFilter.FilteringStrategy.NONE), TagFilter.FilteringStrategy.NONE, 1, new String[]{"facet.tags is NULL OR (facet.tags NOT like '%,foo,%')"});
+        testTagFilter(TagFilter.create(multipleTags, TagFilter.FilteringStrategy.NONE), TagFilter.FilteringStrategy.NONE, 2, new String[]{"facet.tags is NULL OR (", "facet.tags NOT like '%,foo,%'", "AND", "facet.tags NOT like '%,bar,%'",")"});
+        testTagFilter(TagFilter.create(tagsWithDuplicateItems, TagFilter.FilteringStrategy.NONE), TagFilter.FilteringStrategy.NONE, 2, new String[]{"facet.tags is NULL OR (", "facet.tags NOT like '%,foo,%'", "AND", "facet.tags NOT like '%,bar,%'", ")"});
+        testTagFilter(TagFilter.create(tagsWithOneEmptyItem, TagFilter.FilteringStrategy.NONE), TagFilter.FilteringStrategy.NONE, 1, new String[]{"facet.tags is NULL OR (facet.tags NOT like '%,foo,%')"});
     }
 
     private void testUntagged(final TagFilter tagFilter) {
-        testTagFilter(tagFilter, TagFilter.FilteringStrategy.UNTAGGED, 0, "facet.tags is NULL");
+        testTagFilter(tagFilter, TagFilter.FilteringStrategy.UNTAGGED, 0, new String[]{"facet.tags is NULL"});
     }
 
     private void testTagFilter(final TagFilter tagFilter,
                                final TagFilter.FilteringStrategy expectedFilteringStrategy,
                                final int expectedNumberOfTags,
-                               final String expectedWhereClause) {
+                               final String[] expectedWhereClauseParts) {
         Assert.assertNotNull(tagFilter);
         Assert.assertNotNull(tagFilter.getTags());
         Assert.assertEquals(expectedNumberOfTags, tagFilter.getTags().size());
         Assert.assertEquals(expectedFilteringStrategy, tagFilter.getFilteringStrategy());
-        Assert.assertEquals(expectedWhereClause, tagFilter.getWhereClause());
+//        Assert.assertEquals(expectedWhereClause, tagFilter.getWhereClause());
+        
+        String whereClause = tagFilter.getWhereClause();
+        for (String expectedWhereClausePart : expectedWhereClauseParts){
+        	String message = "Validation of where clause failed. Could not find ["+expectedWhereClausePart+"] in ["+whereClause+"]";
+        	Assert.assertTrue(message, whereClause.contains(expectedWhereClausePart));
+        }
     }
+    
 }


### PR DESCRIPTION
For me, these tests failed. The String '%,bar,%' was consistently before the String '%,foo,%'. This change should allow these Strings to be in any order.